### PR TITLE
Ignore docs folder for Publish/Release action

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
 
 env:
   ELECTRON_IS_DEV: 0


### PR DESCRIPTION
No need to run the publish-release action, if nothing in Printdesk core has changed.